### PR TITLE
Enable weekly build schedule

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The DevTools frontend is built from the official Chromium source using the follo
 - gn
 - ninja
 
-The build process runs on GitHub Actions whenever changes are pushed to the main branch. The resulting package is versioned based on the date and commit hash, then published to npm.
+The build process runs on GitHub Actions whenever changes are pushed to the main branch or on a weekly schedule. The resulting package is versioned based on the date and commit hash, then published to npm.
 
 ## License
 


### PR DESCRIPTION
## Summary
- trigger builds weekly on Sunday at midnight
- document weekly schedule in README

## Testing
- `npm install --ignore-scripts`
